### PR TITLE
Fix models not loading

### DIFF
--- a/scripts/renderware/rw_geometry.gd
+++ b/scripts/renderware/rw_geometry.gd
@@ -47,7 +47,7 @@ var mesh: ArrayMesh:
 		
 		for surf_id in surfaces:
 			st.begin(Mesh.PRIMITIVE_TRIANGLES)
-			var surface := surfaces[surf_id] as Array[Triangle]
+			var surface = surfaces[surf_id] as Array[Triangle]
 			for tri in surface:
 				for i in [3,2,1]:
 					if morph_t.has_normals:


### PR DESCRIPTION
As always, the typing system was throwing a tantrum. The error was not caught because it was off-thread.